### PR TITLE
Add Home button to header and convert About link to dropdown list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, Navigate, Route, Routes } from "react-router-dom";
 import About from "./components/About/About";
 import Home from "./components/Home/Home";
@@ -8,9 +8,30 @@ import logo from "./logo.png";
 
 export default function App() {
 
+  const [isDropdownVisible, setIsDropdownVisible] = useState<boolean>(false);
+  const dropdownRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+
+    const func = (event: MouseEvent) => {
+
+      if (!dropdownRef.current || !dropdownRef.current?.contains(event.target as Node)) {
+
+        setIsDropdownVisible(false);
+
+      }
+      
+    };
+
+    document.addEventListener("click", func);
+
+    return () => document.removeEventListener("click", func);
+
+  }, []);
+
   return (
     <>
-      <header>
+      <header onClick={() => setIsDropdownVisible(false)}>
         <Link to="/">
           <img src={logo} />
         </Link>
@@ -19,11 +40,25 @@ export default function App() {
             <li>
               <Link to="/">Home</Link>
             </li>
-            <li>
-              <Link to="/about">About TED</Link>
-            </li>
-            <li>
-              <Link to="/organizers">Organizers</Link>
+            <li id="about">
+              <button ref={dropdownRef} onClick={(event) => {
+                
+                event.stopPropagation();
+                setIsDropdownVisible(!isDropdownVisible);
+                
+              }}>About</button>
+              {
+                isDropdownVisible ? (
+                  <ul>
+                    <li>
+                      <Link to="/about">About TED</Link>
+                    </li>
+                    <li>
+                      <Link to="/organizers">Organizers</Link>
+                    </li>
+                  </ul>
+                ) : null
+              }
             </li>
           </ul>
         </nav>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,9 @@ export default function App() {
         <nav>
           <ul>
             <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
               <Link to="/about">About TED</Link>
             </li>
             <li>

--- a/src/global.css
+++ b/src/global.css
@@ -161,6 +161,28 @@ footer ul {
   flex-direction: column;
   gap: 0;
   right: 20px;
+  margin-top: 10px;
+  border-radius: 5px;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 3px 6px, rgba(0, 0, 0, 0.23) 0px 3px 6px;
+  overflow: hidden;
+}
+
+#about ul li {
+  display: flex;
+  justify-content: center;
+  box-sizing: border-box;
+  align-items: center;
+}
+
+#about ul li a {
+  padding: 5px 15px;
+  height: 100%;
+  background-color: var(--background);
+  transition: 0.05s;
+}
+
+#about ul li a:hover {
+  background-color: #dbdbdb;
 }
 
 @media screen and (min-width: 1080px) {

--- a/src/global.css
+++ b/src/global.css
@@ -145,6 +145,24 @@ footer ul {
   gap: 10px;
 }
 
+#about > button {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  background-color: transparent;
+  color: var(--text);
+  box-shadow: none;
+}
+
+#about ul {
+  position: absolute;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  right: 20px;
+}
+
 @media screen and (min-width: 1080px) {
   
   main {


### PR DESCRIPTION
## Description
<!-- What does this pull request do? -->
This pull request adds a home button to the header and converts the About link to a dropdown list.

## Issues addressed
<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
* #14 
* #15 

## Completion criteria
<!-- Please list what you need to do to complete the implementation -->
* [ ] Add Home button to the header.
* [ ] Convert the About TED link to a dropdown list.
* [ ] Add the Organizers link to the dropdown list.

## Test checks
- [x] To my knowledge, this is not a duplicate pull request.
- [x] My pull request works on the latest stable version of the following browsers:
  - [ ] Microsoft Edge
  - [ ] Google Chrome
  - [x] Mozilla Firefox
  - [ ] Microsoft Edge Android